### PR TITLE
payparams method mistake in iPhone wechat?

### DIFF
--- a/lib/wechatpay/service.rb
+++ b/lib/wechatpay/service.rb
@@ -34,7 +34,8 @@ module Wechatpay
           signType: "MD5"
         }
         options[:paySign] = Wechatpay::Sign.md5(options)
-        options.delete :appId
+        # Why delete the appId here? It causes "Missing appId parameter." error.
+        # options.delete :appId
         options
       end
     end

--- a/lib/wechatpay/utils.rb
+++ b/lib/wechatpay/utils.rb
@@ -42,7 +42,8 @@ module Wechatpay
       end
 
       def timestamp
-        Time.now.to_i
+        # Need to convert timestamp from integer to string. See http://blog.csdn.net/chenyoper/article/details/42496245
+        Time.now.to_i.to_s
       end
 
       def nonce_str

--- a/spec/wechatpay/utils_spec.rb
+++ b/spec/wechatpay/utils_spec.rb
@@ -27,4 +27,10 @@ describe Wechatpay::Utils do
     end
   end
 
+  describe 'timestamp' do
+    it 'should be an integer in string format' do
+      expect(utils.timestamp).to be_kind_of(String)
+      expect(utils.timestamp).to match(/^\d+$/)
+    end
+  end
 end


### PR DESCRIPTION
I met 2 errors why trying this gem out in iPhone:
1. 调用支付JSAPI缺少参数：timeStamp
   Utils.timestamp should return an integer in string format.
2. 调用支付JSAPI缺少参数：appId
   Not sure why you delete the :appId parameter in payparams method, a mistake?
