### PR TITLE
fix case: timeStamp -> timestamp

### DIFF
--- a/lib/wechatpay/service.rb
+++ b/lib/wechatpay/service.rb
@@ -35,6 +35,8 @@ module Wechatpay
         }
         options[:paySign] = Wechatpay::Sign.md5(options)
         options.delete :appId
+        options[:timestamp] = options[:timeStamp]
+        options.delete :timeStamp
         options
       end
     end


### PR DESCRIPTION
See the [docs](http://mp.weixin.qq.com/wiki/7/1c97470084b73f8e224fe6d9bab1625b.html#.E5.8F.91.E8.B5.B7.E4.B8.80.E4.B8.AA.E5.BE.AE.E4.BF.A1.E6.94.AF.E4.BB.98.E8.AF.B7.E6.B1.82), we should use lower `timestamp` instead of `timeStamp` when use the params at the client SDK: `wx.chooseWXPay`.
